### PR TITLE
fix setTemplateDir (using templateDir)

### DIFF
--- a/codegen/src/main/java/org/seasar/doma/gradle/codegen/extension/CodeGenConfig.java
+++ b/codegen/src/main/java/org/seasar/doma/gradle/codegen/extension/CodeGenConfig.java
@@ -367,8 +367,8 @@ public class CodeGenConfig {
     return templateDir;
   }
 
-  public void setTemplateDir(File templateDir) {
-    this.templateDir.set(templateDir);
+  public void setTemplateDir(String templateDir) {
+    this.templateDir.set(new File(templateDir));
   }
 
   public Property<String> getEncoding() {


### PR DESCRIPTION
Hello.

I'm using [doma-codegen-plugin](https://github.com/domaframework/doma-codegen-plugin).
However, the `README.md` method does not work with `Using custom template files`.
This is because 
```
// specify the directory including your custom template files
templateDir = "$projectDir/template"
```
 wants a File type instead of a String type.

I am rewriting this as an easy workaround.
I think this implementation solves the problem but is not smart.
If you can suggest a way to fix it, we will fix it. (I'm not a good Java engineer, so I want to study)
If the README is wrong,I will submit the PR.