### PR TITLE
OracleのDATE型はLocalDateTimeを使用する

### DIFF
--- a/codegen/src/main/java/org/seasar/doma/gradle/codegen/dialect/Oracle11CodeGenDialect.java
+++ b/codegen/src/main/java/org/seasar/doma/gradle/codegen/dialect/Oracle11CodeGenDialect.java
@@ -6,6 +6,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import org.seasar.doma.gradle.codegen.desc.ClassConstants;
@@ -27,6 +28,7 @@ public class Oracle11CodeGenDialect extends StandardCodeGenDialect {
     classNameMap.put("nvarchar2", String.class.getName());
     classNameMap.put("raw", ClassConstants.bytes.getQualifiedName());
     classNameMap.put("varchar2", String.class.getName());
+    classNameMap.put("date", LocalDateTime.class.getName());
   }
 
   @Override


### PR DESCRIPTION
Oracleの日付型は時間も保持している為、
`java.time.LocalDate`より`java.time.LocalDateTime`が適切かと思います。

動作の確認をした環境  
- Oracle Database 19c Enterprise Edition Release 19.0.0.0.0 - Production

