### PR TITLE
Add support for Testcontainers JDBC URLs

### DIFF
--- a/codegen/src/main/java/org/seasar/doma/gradle/codegen/util/JdbcUtil.java
+++ b/codegen/src/main/java/org/seasar/doma/gradle/codegen/util/JdbcUtil.java
@@ -18,7 +18,8 @@ public final class JdbcUtil {
 
   private static final org.slf4j.Logger logger = LoggerFactory.getLogger(JdbcUtil.class);
 
-  protected static final Pattern jdbcUrlPattern = Pattern.compile("jdbc:([^:]+):(([^:]+)?:)?");
+  protected static final Pattern jdbcUrlPattern =
+      Pattern.compile("jdbc:(?:tc:)?([^:]+):(([^:]+)?:)?");
 
   public static Connection getConnection(DataSource dataSource) {
     try {

--- a/codegen/src/test/java/org/seasar/doma/gradle/codegen/util/JdbcUtilTest.java
+++ b/codegen/src/test/java/org/seasar/doma/gradle/codegen/util/JdbcUtilTest.java
@@ -76,4 +76,76 @@ public class JdbcUtilTest {
     String driverClassName = JdbcUtil.inferDriverClassName("localhost/hoge");
     assertNull(driverClassName);
   }
+
+  @Test
+  public void testInferDialectName_testcontainers_postgresql() throws Exception {
+    String dialectName = JdbcUtil.inferDialectName("jdbc:tc:postgresql:13:///test");
+    assertEquals("postgres", dialectName);
+  }
+
+  @Test
+  public void testInferDialectName_testcontainers_mysql() throws Exception {
+    String dialectName = JdbcUtil.inferDialectName("jdbc:tc:mysql:8:///test");
+    assertEquals("mysql", dialectName);
+  }
+
+  @Test
+  public void testInferDialectName_testcontainers_mariadb() throws Exception {
+    String dialectName = JdbcUtil.inferDialectName("jdbc:tc:mariadb:10.5:///test");
+    assertEquals("mysql", dialectName);
+  }
+
+  @Test
+  public void testInferDialectName_testcontainers_oracle() throws Exception {
+    String dialectName = JdbcUtil.inferDialectName("jdbc:tc:oracle:21c:///test");
+    assertEquals("oracle", dialectName);
+  }
+
+  @Test
+  public void testInferDialectName_testcontainers_sqlserver() throws Exception {
+    String dialectName = JdbcUtil.inferDialectName("jdbc:tc:sqlserver:2019:///test");
+    assertEquals("mssql", dialectName);
+  }
+
+  @Test
+  public void testInferDialectName_testcontainers_db2() throws Exception {
+    String dialectName = JdbcUtil.inferDialectName("jdbc:tc:db2:11.5:///test");
+    assertEquals("db2", dialectName);
+  }
+
+  @Test
+  public void testInferDriverClassName_testcontainers_postgresql() throws Exception {
+    String driverClassName = JdbcUtil.inferDriverClassName("jdbc:tc:postgresql:13:///test");
+    assertEquals("org.postgresql.Driver", driverClassName);
+  }
+
+  @Test
+  public void testInferDriverClassName_testcontainers_mysql() throws Exception {
+    String driverClassName = JdbcUtil.inferDriverClassName("jdbc:tc:mysql:8:///test");
+    assertEquals("com.mysql.cj.jdbc.Driver", driverClassName);
+  }
+
+  @Test
+  public void testInferDriverClassName_testcontainers_mariadb() throws Exception {
+    String driverClassName = JdbcUtil.inferDriverClassName("jdbc:tc:mariadb:10.5:///test");
+    assertEquals("org.mariadb.jdbc.Driver", driverClassName);
+  }
+
+  @Test
+  public void testInferDriverClassName_testcontainers_oracle() throws Exception {
+    String driverClassName = JdbcUtil.inferDriverClassName("jdbc:tc:oracle:21c:///test");
+    assertEquals("oracle.jdbc.driver.OracleDriver", driverClassName);
+  }
+
+  @Test
+  public void testInferDriverClassName_testcontainers_sqlserver() throws Exception {
+    String driverClassName = JdbcUtil.inferDriverClassName("jdbc:tc:sqlserver:2019:///test");
+    assertEquals("com.microsoft.sqlserver.jdbc.SQLServerDriver", driverClassName);
+  }
+
+  @Test
+  public void testInferDriverClassName_testcontainers_db2() throws Exception {
+    String driverClassName = JdbcUtil.inferDriverClassName("jdbc:tc:db2:11.5:///test");
+    assertEquals("com.ibm.db2.jcc.DB2Driver", driverClassName);
+  }
 }


### PR DESCRIPTION
## Summary
- Added automatic inference of `dialectName` and `driverClassName` for Testcontainers JDBC URLs
- Enhanced the regex pattern in `JdbcUtil` to handle URLs starting with `jdbc:tc:`
- Added comprehensive tests for all supported database types

## Motivation
When using Testcontainers for integration testing, users currently need to manually specify both the JDBC URL and the dialect/driver configuration. This PR improves the developer experience by automatically inferring these values from Testcontainers URLs.

## Changes
- Updated `jdbcUrlPattern` regex to optionally match the `tc:` prefix in JDBC URLs
- Added test cases for all supported databases (PostgreSQL, MySQL, MariaDB, Oracle, SQL Server, DB2)

## Test plan
- [x] Added unit tests for Testcontainers URL inference
- [x] All existing tests pass
- [x] Code formatted with `./gradlew spotlessApply`

Example usage:
```gradle
domaCodeGen {
    url = "jdbc:tc:postgresql:13:///test"
    // dialectName and driverClassName are now automatically inferred\!
}
```

🤖 Generated with [Claude Code](https://claude.ai/code)