### PR TITLE
Add database connection properties to SqlTestConfig

### DIFF
--- a/codegen/src/main/java/org/seasar/doma/gradle/codegen/extension/SqlTestConfig.java
+++ b/codegen/src/main/java/org/seasar/doma/gradle/codegen/extension/SqlTestConfig.java
@@ -5,14 +5,21 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
 
 public class SqlTestConfig {
 
   private final Property<FileTree> sqlFiles;
+  private final Property<String> url;
+  private final Property<String> user;
+  private final Property<String> password;
 
   @Inject
   public SqlTestConfig(ObjectFactory objects) {
     this.sqlFiles = objects.property(FileTree.class);
+    this.url = objects.property(String.class);
+    this.user = objects.property(String.class);
+    this.password = objects.property(String.class);
   }
 
   @InputFiles
@@ -22,5 +29,32 @@ public class SqlTestConfig {
 
   public void setSqlFiles(FileTree sqlFiles) {
     this.sqlFiles.set(sqlFiles);
+  }
+
+  @Internal
+  public Property<String> getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url.set(url);
+  }
+
+  @Internal
+  public Property<String> getUser() {
+    return user;
+  }
+
+  public void setUser(String user) {
+    this.user.set(user);
+  }
+
+  @Internal
+  public Property<String> getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password.set(password);
   }
 }

--- a/codegen/src/main/java/org/seasar/doma/gradle/codegen/task/CodeGenSqlTestTask.java
+++ b/codegen/src/main/java/org/seasar/doma/gradle/codegen/task/CodeGenSqlTestTask.java
@@ -107,11 +107,14 @@ public class CodeGenSqlTestTask extends DefaultTask {
   }
 
   private SqlTestSuiteDescFactory createSqlTestSuiteDescFactory() {
+    String urlValue = sqlTestConfig.getUrl().getOrElse(url.get());
+    String userValue = sqlTestConfig.getUser().getOrElse(user.get());
+    String passwordValue = sqlTestConfig.getPassword().getOrElse(password.get());
     SqlTestDescFactory sqlTestDescFactory =
         globalFactory
             .get()
             .createSqlTestCaseDescFactory(
-                dialect.get().getDialectClassName(), url.get(), user.get(), password.get());
+                dialect.get().getDialectClassName(), urlValue, userValue, passwordValue);
     return globalFactory.get().createSqlTestSuiteDescFactory(sqlTestDescFactory);
   }
 


### PR DESCRIPTION
## Summary
- Added `url`, `user`, and `password` properties to `SqlTestConfig` class
- Modified `CodeGenSqlTestTask` to use SqlTestConfig's database settings when available
- This enables configuring separate database connections for SQL test tasks

## Test plan
- [x] Build the project with `./gradlew build`
- [x] Run existing tests with `./gradlew test`
- [x] Test SQL test generation with custom database configuration

🤖 Generated with [Claude Code](https://claude.ai/code)