### PR TITLE
Fix SQL test task dependency

### DIFF
--- a/codegen/src/main/java/org/seasar/doma/gradle/codegen/CodeGenPlugin.java
+++ b/codegen/src/main/java/org/seasar/doma/gradle/codegen/CodeGenPlugin.java
@@ -136,7 +136,7 @@ public class CodeGenPlugin implements Plugin<Project> {
         task -> {
           task.setDescription("Generates SQL test source files.");
           task.setGroup(TASK_GROUP_NAME);
-          task.shouldRunAfter(sqlTask);
+          task.dependsOn(sqlTask);
           task.getOutputs().upToDateWhen(__ -> false);
           connectProperties(task, codeGenConfig);
         });


### PR DESCRIPTION
## Summary
- Changed `shouldRunAfter` to `dependsOn` for SQL test tasks to ensure SQL files are generated before tests run
- This prevents test failures caused by missing SQL files when tasks run in parallel

## Test plan
- [ ] Run `./gradlew :codegen-h2-test:domaCodeGenH2SqlTestAll` to verify SQL test files are generated correctly
- [ ] Verify that SQL generation task runs before SQL test task
- [ ] Check that generated test files contain proper test cases for SQL files

🤖 Generated with [Claude Code](https://claude.ai/code)