### PR TITLE
Fix CI workflow and build configuration for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,8 @@ jobs:
 
       - name: Publish plugin
         if: github.event_name == 'push' && endsWith(steps.set-version.outputs.version, 'SNAPSHOT') == false
-        run: ./gradlew :codegen:publishPlugins -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }} -Pgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }}
+        run: >
+          ./gradlew :codegen:publishPlugins 
+          -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }} 
+          -Pgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }}
+          -Pversion=${{ steps.set-version.outputs.version }}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,9 +1,14 @@
 rootProject.name = "doma-codegen-plugin"
 
-pluginManagement {
-    includeBuild("codegen")
-}
+val releaseVersion = settings.startParameter.projectProperties["release.releaseVersion"]
 
-include("codegen-h2-test")
-include("codegen-tc-test")
-include("codegen-template-test")
+if (releaseVersion != null) {
+    include("codegen")
+} else {
+    pluginManagement {
+        includeBuild("codegen")
+    }
+    include("codegen-h2-test")
+    include("codegen-tc-test")
+    include("codegen-template-test")
+}


### PR DESCRIPTION
## Summary
- Improve CI workflow readability with multi-line command formatting
- Add version parameter to publishPlugins task for proper release publishing
- Update settings.gradle.kts to handle release builds differently by switching from includeBuild to regular include

## Test plan
- [ ] Verify CI workflow runs successfully
- [ ] Test that release builds work correctly with the new configuration
- [ ] Confirm that development builds continue to work as before

🤖 Generated with [Claude Code](https://claude.ai/code)