### PR TITLE
Remove gradle from ignoreDeps in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,5 @@
 {
   "extends": [
     "github>domaframework/renovate-config"
-  ],
-  "ignoreDeps": [
-    "gradle"
   ]
 }


### PR DESCRIPTION
## Summary
- Remove gradle from ignoreDeps in renovate.json to allow Renovate to manage Gradle version updates

## Test plan
- [ ] Verify CI passes
- [ ] Confirm Renovate can now create PRs for Gradle updates

🤖 Generated with [Claude Code](https://claude.ai/code)