### PR TITLE
[codex] Remove PAT dependency from release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,17 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to check out"
+        required: false
+        type: string
+      publish:
+        description: "Publish after verification"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -12,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -33,7 +46,7 @@ jobs:
         run: echo ${{ steps.set-version.outputs.version }}
 
       - name: Publish plugin
-        if: github.event_name == 'push' && endsWith(steps.set-version.outputs.version, 'SNAPSHOT') == false
+        if: (github.event_name == 'push' || inputs.publish) && endsWith(steps.set-version.outputs.version, 'SNAPSHOT') == false
         run: >
           ./gradlew :codegen:publishPlugins 
           -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,18 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
+    outputs:
+      release_ref: ${{ steps.release-ref.outputs.release_ref }}
  
     steps:
       - name: Assign input version
-        if: github.event.inputs.version != null
-        run: echo "RELEASE_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+        if: inputs.version != ''
+        run: echo "RELEASE_VERSION=${{ inputs.version }}" >> $GITHUB_ENV
 
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        if: github.event.inputs.version == null
+        if: inputs.version == ''
         id: candidate-version
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -34,7 +38,7 @@ jobs:
             return version.startsWith("v") ? version.substring(1) : version
 
       - name: Assign candidate version
-        if: github.event.inputs.version == null
+        if: inputs.version == ''
         run: echo "RELEASE_VERSION=${{ steps.candidate-version.outputs.result }}" >> $GITHUB_ENV
 
       - name: Set up JDK 21
@@ -46,7 +50,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          fetch-depth: 0
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
@@ -58,9 +62,22 @@ jobs:
           git config --local user.name "GitHub Action"
           ./gradlew release -Prelease.releaseVersion=${{ env.RELEASE_VERSION }}
 
+      - name: Assign release ref
+        id: release-ref
+        run: echo "release_ref=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+
       - name: Upload reports
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build
           path: ./**/build/reports
+
+  verify-and-publish:
+    name: Verify and Publish
+    needs: release
+    uses: ./.github/workflows/ci.yml
+    with:
+      ref: ${{ needs.release.outputs.release_ref }}
+      publish: true
+    secrets: inherit


### PR DESCRIPTION
## Summary
- remove \ usage from the release workflow
- use the default \ with \ for release commits and tags
- call the CI workflow as a reusable workflow so a single \ release still verifies and publishes the released version

## Why
The release workflow depended on a repository PAT for checkout and follow-on automation. This change removes that dependency while keeping the existing release flow intact: the release workflow still starts from \, performs the Gradle release, and then drives publishing for the released ref.

